### PR TITLE
fix: remove integer value from config.template.yaml

### DIFF
--- a/config.template.yaml
+++ b/config.template.yaml
@@ -6,4 +6,4 @@ image_generation_model_name: imagen-3.0-fast-generate-002
 database: (default)
 collection: poses
 test_collection: test-poses
-top_k: 3
+top_k: "3"


### PR DESCRIPTION
Cloudrun deploy from source --env-vars-file cannot receive integer value as env var